### PR TITLE
Use _brand.yml to define colors and typography

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 You only need to do these once locally. 
-* Install [Quarto](https://quarto.org/docs/get-started/)
+* Install [Quarto >= 1.6](https://quarto.org/docs/get-started/)
 * Install the [VS Code Quarto extension](https://quarto.org/docs/get-started/hello/vscode.html)
 
 ## Create a new presentation

--- a/_brand.yml
+++ b/_brand.yml
@@ -1,3 +1,14 @@
+meta:
+  name:
+    short: NIU
+    full: Neuroinformatics Unit
+  link:
+    home: https://neuroinformatics.dev
+    github: https://github.com/neuroinformatics-unit
+    bluesky: https://bsky.app/profile/neuroinformatics.dev
+    mastodon: https://mastodon.online/@neuroinformatics
+    zulip: https://neuroinformatics.zulipchat.com
+
 logo:
   medium: "img/logo_niu_light.png"
 
@@ -48,11 +59,11 @@ defaults:
         auto-animate: true
         auto-play-media: true
         code-overflow: wrap
-        highlight-style: atom-one
+        highlight-style: github
 
       html:
         toc: true
         code-overflow: scroll
-        highlight-style: atom-one
+        highlight-style: github
         embed-resources: true
         page-layout: full

--- a/_brand.yml
+++ b/_brand.yml
@@ -1,0 +1,59 @@
+logo:
+  medium: "img/logo_niu_light.png"
+
+color:
+  palette:
+    white: "#FFFFFF"
+    dark-grey: "#1E1E1E"
+    niu-green: "#03A062"
+    niu-green-dark: "#04B46D"
+    niu-purple: rgb(238 144 64)
+    bg-orange: "#EE9040"
+    bg-blue: "#459db9"
+  background: white
+  foreground: dark-grey
+  primary: niu-green
+  info: bg-blue
+  success: "niu-green"
+  warning: "bg-orange"
+
+
+typography:
+  fonts:
+    - family: Barlow
+      source: google
+    - family: JetBrains Mono
+      source: google
+  base:
+    family: Barlow
+  headings:
+    family: Barlow
+    weight: 600
+  link:
+    color: primary
+  monospace:
+    family: JetBrains Mono
+
+defaults:
+  quarto:
+    format:
+      revealjs:
+        slide-number: c
+        menu:
+            numbers: true
+        chalkboard: true
+        scrollable: true
+        preview-links: false
+        view-distance: 10
+        mobile-view-distance: 10
+        auto-animate: true
+        auto-play-media: true
+        code-overflow: wrap
+        highlight-style: atom-one
+
+      html:
+        toc: true
+        code-overflow: scroll
+        highlight-style: atom-one
+        embed-resources: true
+        page-layout: full

--- a/_brand.yml
+++ b/_brand.yml
@@ -7,7 +7,6 @@ color:
     dark-grey: "#1E1E1E"
     niu-green: "#03A062"
     niu-green-dark: "#04B46D"
-    niu-purple: rgb(238 144 64)
     bg-orange: "#EE9040"
     bg-blue: "#459db9"
   background: white

--- a/_brand.yml
+++ b/_brand.yml
@@ -43,27 +43,3 @@ typography:
     color: primary
   monospace:
     family: JetBrains Mono
-
-defaults:
-  quarto:
-    format:
-      revealjs:
-        slide-number: c
-        menu:
-            numbers: true
-        chalkboard: true
-        scrollable: true
-        preview-links: false
-        view-distance: 10
-        mobile-view-distance: 10
-        auto-animate: true
-        auto-play-media: true
-        code-overflow: wrap
-        highlight-style: github
-
-      html:
-        toc: true
-        code-overflow: scroll
-        highlight-style: github
-        embed-resources: true
-        page-layout: full

--- a/_brand.yml
+++ b/_brand.yml
@@ -10,7 +10,7 @@ meta:
     zulip: https://neuroinformatics.zulipchat.com
 
 logo:
-  medium: "img/logo_niu_light.png"
+  medium: "img/logo_niu_light.png"  # change to logo_niu_dark.png for dark mode
 
 color:
   palette:
@@ -20,12 +20,13 @@ color:
     niu-green-dark: "#04B46D"
     bg-orange: "#EE9040"
     bg-blue: "#459db9"
+  # Flip the background/foregroud colors for dark mode
   background: white
   foreground: dark-grey
-  primary: niu-green
+  primary: niu-green     # use niu-green-dark for dark mode
   info: bg-blue
-  success: "niu-green"
-  warning: "bg-orange"
+  success: niu-green     # use niu-green-dark for dark mode
+  warning: bg-orange
 
 
 typography:

--- a/index.qmd
+++ b/index.qmd
@@ -4,39 +4,9 @@ execute:
   enabled: true
 format:
     revealjs:
-        theme: [default, niu-light.scss]
-        logo: img/logo_niu_light.png
         footer: "Tea hour | 2025-04-11"
-        slide-number: c
-        menu:
-            numbers: true
-        chalkboard: true
-        scrollable: true
-        preview-links: false
-        view-distance: 10
-        mobile-view-distance: 10
-        auto-animate: true
-        auto-play-media: true
-        code-overflow: wrap
-        highlight-style: atom-one
-        mermaid: 
-          theme: neutral
-          fontFamily: arial
-          curve: linear
     html:
-        theme: [default, niu-light.scss]
-        logo: img/logo_niu_light.png
-        date: "2023-07-05"
-        toc: true
-        code-overflow: scroll
-        highlight-style: atom-one
-        mermaid: 
-          theme: neutral
-          fontFamily: arial
-          curve: linear
-          margin-left: 0
-        embed-resources: true
-        page-layout: full
+        date: "2025-04-11"
 my-custom-stuff:
    my-reuseable-variable: "I can use this wherever I want in the markdown, and change it in only once place :)"
 ---

--- a/index.qmd
+++ b/index.qmd
@@ -3,10 +3,28 @@ title: SWC/GCNU Neuroinformatics Unit
 execute: 
   enabled: true
 format:
-    revealjs:
-        footer: "Tea hour | 2025-04-11"
-    html:
-        date: "2025-04-11"
+  revealjs:  # settings for rendering to slides
+    footer: "Tea hour | 2025-04-11"
+    slide-number: c
+    menu:
+        numbers: true
+    chalkboard: true
+    scrollable: true
+    preview-links: false
+    view-distance: 10
+    mobile-view-distance: 10
+    auto-animate: true
+    auto-play-media: true
+    code-overflow: wrap
+    highlight-style: atom-one
+  html:    # settings for rendering to single html webpage
+    date: "2025-04-11"
+    toc: true
+    code-overflow: scroll
+    highlight-style: atom-one
+    embed-resources: true
+    page-layout: full
+
 my-custom-stuff:
    my-reuseable-variable: "I can use this wherever I want in the markdown, and change it in only once place :)"
 ---

--- a/niu-dark.scss
+++ b/niu-dark.scss
@@ -1,8 +1,0 @@
-/*-- scss:defaults --*/
-
-$body-bg: #1E1E1E !default;
-$body-color: #fff !default;
-$link-color: #04B46D !default;
-$font-family-sans-serif: arial, "open sans", "helvetica neue", helvetica, sans-serif !default;
-$mermaid-font-family: arial;
-/*-- scss:rules --*/

--- a/niu-light.scss
+++ b/niu-light.scss
@@ -1,8 +1,0 @@
-/*-- scss:defaults --*/
-
-$body-bg: #fff !default;
-$body-color: #1E1E1E !default;
-$link-color: #03A062 !default;
-$font-family-sans-serif: arial, "open sans", "helvetica neue", helvetica, sans-serif !default;
-$mermaid-font-family: arial;
-/*-- scss:rules --*/


### PR DESCRIPTION
Closes #6.

I made use of a relatively new quarto feature, the [_brand.yml](https://quarto.org/docs/authoring/brand.html) file (see [here](https://posit-dev.github.io/brand-yml/) for the full schema), to define a consistent style that can be applied to all of our quarto outputs (irrespective of format). It's automatically applied since it's in the same folder as `index.qmd`.

In `_brand.yml` I define colours (I've included named colours we use across NIU and BrainGlobe websites) and typography (I made some opinionated choices here, feel free to disagree). 

Some of these definitions can be re-used inside `index.qmd`, e.g. using the ``{{< brand color primary >}}`` syntax.

This means we no longer need the .scss files, as all relevant variables can be configured directly in the `_brand.yml`. This file is also portable, so we can easily copy it to our other quarto projects.